### PR TITLE
Fixed Android 8.0 crash

### DIFF
--- a/app/src/main/java/com/felkertech/ussenterprise/fragments/PersonalFragment.java
+++ b/app/src/main/java/com/felkertech/ussenterprise/fragments/PersonalFragment.java
@@ -154,6 +154,10 @@ public class PersonalFragment extends Fragment {
     }
 
     private void Wifid(String log) {
+       if (getView() == null) { // handle if there is no list
+            Toast.makeText(getContext(), log, Toast.LENGTH_SHORT).show();
+            return;
+        }
         TextView logView = ((TextView) getView().findViewById(R.id.wifi_list));
         logView.setText(log + "          " + logView.getText());
     }


### PR DESCRIPTION
Bug Report : https://github.com/ITVlab/Enterprise-Wi-Fi/issues/4

What's wrong : Wifid method was not handled properly. Fixed the handling for it , so that it does not crash in Android TV running Android version 8.0 above

Tested on : NZ SmartVu Box (runs Android 8.0 with Android TV).

This fixes the crash and I am able to use the app. However,  I cannot add any other WiFi (that's a different issue which I am currently investigating) 
